### PR TITLE
Update to version v0.2.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,19 @@ task:
     JULIA_VERSION: 1.9
     JULIA_VERSION: nightly
   allow_failures: $JULIA_VERSION == 'nightly'
-  install_script:
-    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  install_script: |
+    URL="https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh"
+    if [ "$(uname)" = "Linux" ] && command -v apt; then
+        apt update
+        apt install -y curl
+    fi
+    if command -v curl; then
+        sh -c "$(curl ${URL})"
+    elif command -v wget; then
+        sh -c "$(wget ${URL} -q -O-)"
+    elif command -v fetch; then
+        sh -c "$(fetch ${URL} -o -)"
+    fi
   build_script:
     - cirrusjl build
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,7 @@ task:
   env:
     JULIA_VERSION: 1.0
     JULIA_VERSION: 1.8
+    JULIA_VERSION: 1.9
     JULIA_VERSION: nightly
   allow_failures: $JULIA_VERSION == 'nightly'
   install_script:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleCaching"
 uuid = "71e1c77a-176e-49fd-a90f-f84a4a948e95"
-authors = ["Federico MANZELLA"]
-version = "0.2.1"
+authors = ["Federico Manzella"]
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,12 +23,12 @@ the result can be loaded from the cache, if any.
 
 ## Installation
 
-Currently this packages is still not registered so you need to execute the following
-commands in a Julia REPL to install it:
+This packages is registered so you can install it by executing the following commands in a
+Julia REPL:
 
 ```julia
 import Pkg
-Pkg.add("https://github.com/ferdiu/SimpleCaching.jl")
+Pkg.add("SimpleCaching")
 ```
 
 or, to install the developement version, run:

--- a/docs/src/macros.md
+++ b/docs/src/macros.md
@@ -7,7 +7,7 @@ CurrentModule = SimpleCaching
 All the macros can be described as one:
 
 ```julia
-@scache[jld][_if condition] type cache_dir function_call
+@scache[jld][_if condition] [[type] cache_dir] function_call
 ```
 
 when `jld` is specified right after `@scache` then `JLD2` will be used instead of

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -195,8 +195,19 @@ so the cached file will be loaded even if the arguments are different but will e
 the same result.
 """
 
+const _type_docs = """!!! note
+
+    If `type` is omitted the function name will be used as `type`.
 """
-	scache(type, cache_dir, function_call)
+
+const _cache_dir_docs = """!!! note
+
+    If `cache_dir` is omitted the value set in filed `cache_dir` in
+    [`SimpleCachingSettings`](@ref) will be used.
+"""
+
+"""
+	@scache [[type] cache_dir] function_call
 
 Cache the result of `function_call` in directory `cache_dir` prefixing the saved file with
 `type`.
@@ -206,6 +217,10 @@ files so it is faster and more memory efficent than [`@scachejld`](@ref) macro w
 `JLD2` which, on the other hand, is more portable between different julia versions.
 
 $_ext_docs
+
+$_type_docs
+
+$_cache_dir_docs
 
 ## Examples
 ```julia-repl
@@ -284,10 +299,21 @@ macro scache(type, common_cache_dir, ex)
 
 	:(@_scache $(esc(type)) $(esc(common_cache_dir)) $(esc(ex)))
 end
+macro scache(common_cache_dir, ex)
+	uex = unesc_comp(ex)
+
+	(typeof(uex) != Expr || uex.head != :call) && (throw(ArgumentError("`@scache[jld]` can " *
+		"be used only with function calls: passed $(uex)")))
+
+	:(@scache $(esc(string(uex.args[1]))) $(esc(common_cache_dir)) $(esc(ex)))
+end
+macro scache(ex)
+	:(@scache $(esc(settings.cache_dir)) $(esc(ex)))
+end
 
 
 """
-	scachejld(type, cache_dir, function_call)
+	@scachejld [[type] cache_dir] function_call
 
 Cache the result of `function_call` in directory `cache_dir` prefixing the saved file with
 `type`.
@@ -297,6 +323,10 @@ slower and less memory efficent than [`@scache`](@ref) macro which uses `seriali
 which, on the other hand, is less portable between different julia versions.
 
 $_ext_docs
+
+$_type_docs
+
+$_cache_dir_docs
 
 ## Examples
 ```julia-repl
@@ -375,9 +405,20 @@ macro scachejld(type, common_cache_dir, ex)
 
 	:(@_scache $(esc(type)) $(esc(common_cache_dir)) $(esc(ex)))
 end
+macro scachejld(common_cache_dir, ex)
+    uex = unesc_comp(ex)
+
+    (typeof(uex) != Expr || uex.head != :call) && (throw(ArgumentError("`@scache[jld]` can " *
+        "be used only with function calls: passed $(uex)")))
+
+    :(@scachejld $(esc(string(uex.args[1]))) $(esc(common_cache_dir)) $(esc(ex)))
+end
+macro scachejld(ex)
+    :(@scachejld $(esc(settings.cache_dir)) $(esc(ex)))
+end
 
 """
-	scache_if(condition, type, cache_dir, function_call)
+	@scache_if condition [[type] cache_dir] function_call
 
 Cache the result of `function_call` only if `condition` is `true`.
 
@@ -465,9 +506,20 @@ macro scache_if(condition, type, common_cache_dir, ex)
 		end
 	end
 end
+macro scache_if(condition, common_cache_dir, ex)
+    uex = unesc_comp(ex)
+
+    (typeof(uex) != Expr || uex.head != :call) && (throw(ArgumentError("`@scache[jld]` can " *
+        "be used only with function calls: passed $(uex)")))
+
+    :(@scache_if $(esc(condition)) $(esc(string(uex.args[1]))) $(esc(common_cache_dir)) $(esc(ex)))
+end
+macro scache_if(condition, ex)
+    :(@scache_if $(esc(condition)) $(esc(settings.cache_dir)) $(esc(ex)))
+end
 
 """
-	scachejld_if(condition, type, cache_dir, function_call)
+	@scachejld_if condition [[type] cache_dir] function_call
 
 Cache the result of `function_call` only if `condition` is `true`.
 
@@ -554,4 +606,15 @@ macro scachejld_if(condition, type, common_cache_dir, ex)
 			$(esc(ex))
 		end
 	end
+end
+macro scachejld_if(condition, common_cache_dir, ex)
+    uex = unesc_comp(ex)
+
+    (typeof(uex) != Expr || uex.head != :call) && (throw(ArgumentError("`@scache[jld]` can " *
+        "be used only with function calls: passed $(uex)")))
+
+    :(@scachejld_if $(esc(condition)) $(esc(string(uex.args[1]))) $(esc(common_cache_dir)) $(esc(ex)))
+end
+macro scachejld_if(condition, ex)
+    :(@scachejld_if $(esc(condition)) $(esc(settings.cache_dir)) $(esc(ex)))
 end

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -14,7 +14,9 @@ SimpleCachingSettings is a struct containing settings for exported macros `@scac
 - `line_started`: a String that will be placed at the beginning of the log; ignored if `log`
     is `false`. Default is `"● "`.
 - `create_cache_record`: a Bool indicating whether to create a tsv file containing human
-    readable informations about the saved file. Default is `false`.
+    readable informations about the saved file. Default is `false`;
+- `cache_dir`: this is the default directory the cache will be saved in when not specified
+    in the macro call. Default is `./_sc_cache`.
 """
 mutable struct SimpleCachingSettings
     log::Bool
@@ -22,13 +24,14 @@ mutable struct SimpleCachingSettings
     date_format::AbstractString
     line_starter::AbstractString
     create_cache_record::Bool
+    cache_dir::AbstractString
 end
 
-const settings = SimpleCachingSettings(false, stdout, "yyyy-mm-dd HH:MM:SS", "● ", false)
+const settings = SimpleCachingSettings(false, stdout, "yyyy-mm-dd HH:MM:SS", "● ", false, "./_sc_cache")
 
 _use_serialize = false
 
-_closelog(io::IO) = nothing
+_closelog(::IO) = nothing
 _closelog(io::IOStream) = close(io)
 _closelog(io::Channel) = close(io)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ end
 @testset "SimpleCaching.jl" begin
     # test @scache
     res1 = @scache cached_type testing_cache_dir fill(0.0, 10, 10, 10)
+    @test isdir(testing_cache_dir)
     res2 = @scache cached_type testing_cache_dir fill(0.0, 10, 10, 10)
     res3 = @scache cached_type testing_cache_dir fill(Float64(1 - 1), 10, 10, 10)
     res4 = @scache cached_type testing_cache_dir fill(res3[1,1,1], 10, 10, 10)
@@ -41,8 +42,157 @@ end
     @test res3 == res
     @test res4 == res
 
+    rm(testing_cache_dir; recursive = true)
+
+    @testset "no type" begin
+        # test @scache
+        res1 = @scache testing_cache_dir fill(0.0, 10, 10, 10)
+        @test isdir(testing_cache_dir)
+        res2 = @scache testing_cache_dir fill(0.0, 10, 10, 10)
+        res3 = @scache testing_cache_dir fill(Float64(1 - 1), 10, 10, 10)
+        res4 = @scache testing_cache_dir fill(res3[1,1,1], 10, 10, 10)
+
+        res = fill(0.0, 10, 10, 10)
+
+        @test res1 == res
+        @test res2 == res
+        @test res3 == res
+        @test res4 == res
+
+        # test @scachejld
+        res1 = @scachejld testing_cache_dir fill(0.0, 20, 20, 20)
+        res2 = @scachejld testing_cache_dir fill(0.0, 20, 20, 20)
+        res3 = @scachejld testing_cache_dir fill(Float64(1 - 1), 20, 20, 20)
+        res4 = @scachejld testing_cache_dir fill(res3[1,1,1], 20, 20, 20)
+
+        res = fill(0.0, 20, 20, 20)
+
+        @test res1 == res
+        @test res2 == res
+        @test res3 == res
+        @test res4 == res
+
+        rm(testing_cache_dir; recursive = true)
+
+        @testset "no dir" begin
+            # test @scache
+            res1 = @scache fill(0.0, 10, 10, 10)
+            @test isdir(SimpleCaching.settings.cache_dir)
+            res2 = @scache fill(0.0, 10, 10, 10)
+            res3 = @scache fill(Float64(1 - 1), 10, 10, 10)
+            res4 = @scache fill(res3[1,1,1], 10, 10, 10)
+
+            res = fill(0.0, 10, 10, 10)
+
+            @test res1 == res
+            @test res2 == res
+            @test res3 == res
+            @test res4 == res
+
+            # test @scachejld
+            res1 = @scachejld fill(0.0, 20, 20, 20)
+            res2 = @scachejld fill(0.0, 20, 20, 20)
+            res3 = @scachejld fill(Float64(1 - 1), 20, 20, 20)
+            res4 = @scachejld fill(res3[1,1,1], 20, 20, 20)
+
+            res = fill(0.0, 20, 20, 20)
+
+            @test res1 == res
+            @test res2 == res
+            @test res3 == res
+            @test res4 == res
+
+            rm(SimpleCaching.settings.cache_dir; recursive = true)
+        end
+    end
+
+    @testset "conditionals" begin
+        # test @scache_if
+        res = fill(0.0, 10, 10, 10)
+
+        res1 = @scache_if false cached_type testing_cache_dir fill(0.0, 10, 10, 10)
+        @test !isdir(testing_cache_dir)
+        @test res1 == res
+
+        res1 = @scache_if true cached_type testing_cache_dir fill(0.0, 10, 10, 10)
+        @test isdir(testing_cache_dir)
+        @test res1 == res
+
+        rm(testing_cache_dir; recursive = true)
+
+        # test @scachejld_if
+        res = fill(0.0, 10, 10, 10)
+
+        res1 = @scachejld_if false cached_type testing_cache_dir fill(0.0, 10, 10, 10)
+        @test !isdir(testing_cache_dir)
+        @test res1 == res
+
+        res1 = @scachejld_if true cached_type testing_cache_dir fill(0.0, 10, 10, 10)
+        @test isdir(testing_cache_dir)
+        @test res1 == res
+
+        rm(testing_cache_dir; recursive = true)
+
+        @testset "no type" begin
+            # test @scache_if
+            res = fill(0.0, 10, 10, 10)
+
+            res1 = @scache_if false testing_cache_dir fill(0.0, 10, 10, 10)
+            @test !isdir(testing_cache_dir)
+            @test res1 == res
+
+            res1 = @scache_if true testing_cache_dir fill(0.0, 10, 10, 10)
+            @test isdir(testing_cache_dir)
+            @test res1 == res
+
+            rm(testing_cache_dir; recursive = true)
+
+            # test @scachejld_if
+            res = fill(0.0, 10, 10, 10)
+
+            res1 = @scachejld_if false testing_cache_dir fill(0.0, 10, 10, 10)
+            @test !isdir(testing_cache_dir)
+            @test res1 == res
+
+            res1 = @scachejld_if true testing_cache_dir fill(0.0, 10, 10, 10)
+            @test isdir(testing_cache_dir)
+            @test res1 == res
+
+            rm(testing_cache_dir; recursive = true)
+
+            @testset "no dir" begin
+                # test @scache_if
+                res = fill(0.0, 10, 10, 10)
+
+                res1 = @scache_if false fill(0.0, 10, 10, 10)
+                @test !isdir(SimpleCaching.settings.cache_dir)
+                @test res1 == res
+
+                res1 = @scache_if true fill(0.0, 10, 10, 10)
+                @test isdir(SimpleCaching.settings.cache_dir)
+                @test res1 == res
+
+                rm(SimpleCaching.settings.cache_dir; recursive = true)
+
+                # test @scachejld_if
+                res = fill(0.0, 10, 10, 10)
+
+                res1 = @scachejld_if false fill(0.0, 10, 10, 10)
+                @test !isdir(SimpleCaching.settings.cache_dir)
+                @test res1 == res
+
+                res1 = @scachejld_if true fill(0.0, 10, 10, 10)
+                @test isdir(SimpleCaching.settings.cache_dir)
+                @test res1 == res
+
+                rm(SimpleCaching.settings.cache_dir; recursive = true)
+            end
+        end
+    end
+
     # test using macro within another module
     using .A
+    res = fill(0.0, 20, 20, 20)
     hc = heavy_computation(cached_type, testing_cache_dir, 0.0, 20, 20, 20)
 
     @test hc == res


### PR DESCRIPTION
# New in v0.2.2

This version adds new macros allowing the user to omit `type` and `cache_dir` parameters when calling `@scache[jld][_if]` macros.

### Other minor changes

- Fix: `.cirrus.yml` CI not working on Linux;
- Update: documentation (new features and now the documentation says that the package is registered);
- Update: more tests.
